### PR TITLE
Fix Unary Operator Precedence

### DIFF
--- a/src/main/antlr4/com/yahoo/bullet/bql/parser/BQLBase.g4
+++ b/src/main/antlr4/com/yahoo/bullet/bql/parser/BQLBase.g4
@@ -86,7 +86,8 @@ expression
     | subFieldExpression (':' fieldType)?                                                                               #subField
     | subSubFieldExpression (':' fieldType)?                                                                            #subSubField
     | listExpression                                                                                                    #list
-    | unaryExpression                                                                                                   #unary
+    | op=(NOT | SIZEOF | ABS | TRIM | LOWER | UPPER | HASH) parens='(' operand=expression ')'                           #unary
+    | op=(NOT | SIZEOF) operand=expression                                                                              #unary
     | functionExpression                                                                                                #function
     | expression IS NOT? NULL                                                                                           #nullPredicate
     | left=expression op=(ASTERISK | SLASH | PERCENT) right=expression                                                  #infix
@@ -135,11 +136,6 @@ subSubFieldExpression
 listExpression
     : '[' ']'
     | '[' expressions ']'
-    ;
-
-unaryExpression
-    : op=(NOT | SIZEOF | ABS | TRIM | LOWER | UPPER | HASH) parens='(' operand=expression ')'
-    | op=(NOT | SIZEOF) operand=expression
     ;
 
 functionExpression

--- a/src/main/java/com/yahoo/bullet/bql/parser/ASTBuilder.java
+++ b/src/main/java/com/yahoo/bullet/bql/parser/ASTBuilder.java
@@ -247,7 +247,7 @@ class ASTBuilder extends BQLBaseBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitUnaryExpression(BQLBaseParser.UnaryExpressionContext context) {
+    public Node visitUnary(BQLBaseParser.UnaryContext context) {
         return new UnaryExpressionNode(getOperation(context.op),
                                        (ExpressionNode) visit(context.expression()),
                                        context.parens != null,

--- a/src/test/java/com/yahoo/bullet/bql/integration/ExpressionTest.java
+++ b/src/test/java/com/yahoo/bullet/bql/integration/ExpressionTest.java
@@ -751,4 +751,13 @@ public class ExpressionTest extends IntegrationTest {
                                                                                         Operation.AND,
                                                                                         Type.BOOLEAN));
     }
+
+    @Test
+    public void testUnaryOperatorPrecedence() {
+        build("SELECT NOT true AND false FROM STREAM()");
+        Assert.assertEquals(query.getProjection().getFields().get(0).getValue(), binary(unary(value(true), Operation.NOT, Type.BOOLEAN),
+                                                                                        value(false),
+                                                                                        Operation.AND,
+                                                                                        Type.BOOLEAN));
+    }
 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

For some ANTLR reason, unary operator precedence was lower than intended sigh.. (only a problem without parentheses)